### PR TITLE
Chore/25 tab bar color

### DIFF
--- a/Alarm/Resources/Assets.xcassets/backgroundColor.colorset/Contents.json
+++ b/Alarm/Resources/Assets.xcassets/backgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x17",
+          "green" : "0x1B",
+          "red" : "0x1F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x17",
+          "green" : "0x1B",
+          "red" : "0x1F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarm/Resources/Assets.xcassets/mainColor.colorset/Contents.json
+++ b/Alarm/Resources/Assets.xcassets/mainColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xCC",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xCC",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarm/Resources/Assets.xcassets/modalColor.colorset/Contents.json
+++ b/Alarm/Resources/Assets.xcassets/modalColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x36",
+          "red" : "0x36"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x36",
+          "red" : "0x36"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarm/Resources/Assets.xcassets/sectionColor.colorset/Contents.json
+++ b/Alarm/Resources/Assets.xcassets/sectionColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x29",
+          "green" : "0x24",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x29",
+          "green" : "0x24",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarm/Scenes/RootScene/MainTabBarController.swift
+++ b/Alarm/Scenes/RootScene/MainTabBarController.swift
@@ -50,10 +50,12 @@ final class MainTabBarController: UITabBarController {
     // 배경 색 다크
     appearance.backgroundColor = .black
 
+    let mainColor = UIColor(named: "mainColor") ?? .systemBlue
+
     // 선택된 아이콘 색
     let selected = appearance.stackedLayoutAppearance.selected
-    selected.iconColor = .systemOrange
-    selected.titleTextAttributes = [.foregroundColor: UIColor.systemOrange]
+    selected.iconColor = mainColor
+    selected.titleTextAttributes = [.foregroundColor: mainColor]
 
     // 비선택 아이템 색
     let normal = appearance.stackedLayoutAppearance.normal


### PR DESCRIPTION
## 🔗 관련 이슈

- #25 

## 🔧 PR 요약

- 원래 주황색이었던 하단 tabBar 색상을 mainColor로 변경하였습니다

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
<img width="300" height="700" alt="simulator_screenshot_2DB4DF4D-6E54-4B9C-B526-88157B2D0D68" src="https://github.com/user-attachments/assets/5d00397d-49df-45ad-aadb-590e3668d42f" />