### PR TITLE
타이머 데이터 등록 및 테이블 뷰에 표시

### DIFF
--- a/Alarm/Scenes/Timer/AddTimerViewController.swift
+++ b/Alarm/Scenes/Timer/AddTimerViewController.swift
@@ -1,0 +1,70 @@
+//
+//  AddTimerViewController.swift
+//  Alarm
+//
+//  Created by luca on 8/6/25.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+class AddTimerViewController: UIViewController {
+  let timerPicker = TimerPickerView()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    configureUI()
+    setupViews()
+    setupNavigationBar()
+    addTarget()
+  }
+
+  private func configureUI() {
+    view.backgroundColor = .systemBackground
+    title = "타이머"
+    navigationController?.navigationBar.prefersLargeTitles = true
+    navigationItem.largeTitleDisplayMode = .always
+  }
+  
+  private func setupViews() {
+    view.addSubview(timerPicker)
+    timerPicker.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide)
+      $0.horizontalEdges.equalToSuperview()
+      $0.centerX.equalToSuperview()
+    }
+  }
+
+  private func setupNavigationBar() {
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "시작", style: .plain, target: self, action: #selector(addTimer)
+    ).then {
+      $0.tintColor = .systemOrange
+    }
+
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      title: "취소",
+      primaryAction: UIAction { [weak self] _ in
+        self?.dismiss(animated: true)
+      },
+      menu: nil
+    ).then {
+      $0.tintColor = .systemOrange
+    }
+  }
+  
+  private func addTarget() {
+    addTimer()
+  }
+  
+  @objc private func addTimer() {
+    let selectedSeconds = timerPicker.selectedTimeInterval()
+    print(selectedSeconds)
+  }
+  
+  @objc private func handleTimeChanged(_ sender: UIDatePicker) {
+    print(sender.date)
+  }
+}

--- a/Alarm/Scenes/Timer/AddTimerViewController.swift
+++ b/Alarm/Scenes/Timer/AddTimerViewController.swift
@@ -5,20 +5,18 @@
 //  Created by luca on 8/6/25.
 //
 
-import UIKit
-import Then
 import SnapKit
+import Then
+import UIKit
 
 class AddTimerViewController: UIViewController {
   let timerPicker = TimerPickerView()
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    
     configureUI()
     setupViews()
     setupNavigationBar()
-    addTarget()
   }
 
   private func configureUI() {
@@ -27,7 +25,7 @@ class AddTimerViewController: UIViewController {
     navigationController?.navigationBar.prefersLargeTitles = true
     navigationItem.largeTitleDisplayMode = .always
   }
-  
+
   private func setupViews() {
     view.addSubview(timerPicker)
     timerPicker.snp.makeConstraints {
@@ -37,9 +35,13 @@ class AddTimerViewController: UIViewController {
     }
   }
 
+  // 내비게이션 버튼
   private func setupNavigationBar() {
     navigationItem.rightBarButtonItem = UIBarButtonItem(
-      title: "시작", style: .plain, target: self, action: #selector(addTimer)
+      title: "시작",
+      style: .plain,
+      target: self,
+      action: #selector(addTimer)
     ).then {
       $0.tintColor = UIColor(named: "mainColor")
     }
@@ -55,16 +57,38 @@ class AddTimerViewController: UIViewController {
     }
   }
   
-  private func addTarget() {
-    addTimer()
-  }
-  
-  @objc private func addTimer() {
+  // MARK: Button function
+
+  @objc private func addTimer() { // 타이머 추가(userDefault에 저장) 액션
     let selectedSeconds = timerPicker.selectedTimeInterval()
-    print(selectedSeconds)
-  }
-  
-  @objc private func handleTimeChanged(_ sender: UIDatePicker) {
-    print(sender.date)
+    let time = timerPicker.selectedTimeComponents()
+    var userLabelText = timerPicker.userLabelText()
+    if userLabelText.isEmpty {
+      if time.hour != 0 {
+        userLabelText += "\(time.hour)시간"
+      }
+      if time.minute != 0 {
+        userLabelText += " \(time.minute)분"
+      }
+      if time.second != 0 {
+        userLabelText += " \(time.second)초"
+      }
+    }
+    
+    let newItem = TimerItem(
+      id: UUID(),
+      time: selectedSeconds,
+      label: userLabelText,
+      isActive: true
+    )
+
+    // userDefault에 저장
+    TimerDataManager.shared.addTimter(newItem)
+    dismiss(animated: true)
+    
+    // var timers = TimerDataManager.shared.loadTimers()
+    // timers.append(newItem)
+    // TimerDataManager.shared.saveTimers(timers)
+    // NotificationCenter.default.post(name: .timerDidAdd, object: newItem)
   }
 }

--- a/Alarm/Scenes/Timer/AddTimerViewController.swift
+++ b/Alarm/Scenes/Timer/AddTimerViewController.swift
@@ -22,7 +22,7 @@ class AddTimerViewController: UIViewController {
   }
 
   private func configureUI() {
-    view.backgroundColor = .systemBackground
+    view.backgroundColor = UIColor(named: "backgroundColor")
     title = "타이머"
     navigationController?.navigationBar.prefersLargeTitles = true
     navigationItem.largeTitleDisplayMode = .always
@@ -41,7 +41,7 @@ class AddTimerViewController: UIViewController {
     navigationItem.rightBarButtonItem = UIBarButtonItem(
       title: "시작", style: .plain, target: self, action: #selector(addTimer)
     ).then {
-      $0.tintColor = .systemOrange
+      $0.tintColor = UIColor(named: "mainColor")
     }
 
     navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -51,7 +51,7 @@ class AddTimerViewController: UIViewController {
       },
       menu: nil
     ).then {
-      $0.tintColor = .systemOrange
+      $0.tintColor = UIColor(named: "mainColor")
     }
   }
   

--- a/Alarm/Scenes/Timer/TimerDataManager.swift
+++ b/Alarm/Scenes/Timer/TimerDataManager.swift
@@ -1,0 +1,57 @@
+//
+//  TimerDataManager.swift
+//  Alarm
+//
+//  Created by luca on 8/7/25.
+//
+
+import Foundation
+import RxSwift
+
+final class TimerDataManager {  // 타이머 데이터 저장/조회
+  static let shared = TimerDataManager()
+  private init() {}
+  private let key = "savedTimers"
+
+  let timers = BehaviorSubject<[TimerItem]>(value: [])
+
+  func saveTimers() {  // userDefault 전체 배열 저장
+    if let items = try? timers.value(),
+      let data = try? JSONEncoder().encode(items)
+    {
+      UserDefaults.standard.set(data, forKey: key)
+    }
+  }
+
+  func loadTimers() { // userDefault 조회
+      if let data = UserDefaults.standard.data(forKey: key),
+         let loaded = try? JSONDecoder().decode([TimerItem].self, from: data) {
+          timers.onNext(loaded)
+      }
+  }
+  
+  func addTimter(_ timer: TimerItem) { // 배열에 데이터 추가
+    var current = (try? timers.value()) ?? []
+    current.append(timer)
+    timers.onNext(current)
+    saveTimers()
+  }
+  
+  func removeTimer(at index: Int) {
+    var current = (try? timers.value()) ?? []
+    guard current.indices.contains(index) else { return }
+    current.remove(at: index)
+    timers.onNext(current)
+    saveTimers()
+  }
+  
+}
+
+// MARK: - UITableViewDataStruct
+
+struct TimerItem: Codable {
+  let id: UUID
+  let time: TimeInterval
+  let label: String
+  let isActive: Bool
+}

--- a/Alarm/Scenes/Timer/TimerPickerView.swift
+++ b/Alarm/Scenes/Timer/TimerPickerView.swift
@@ -1,0 +1,162 @@
+//
+//  TimerPickerView.swift
+//  Alarm
+//
+//  Created by luca on 8/6/25.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class TimerPickerView: UIView {
+  private let timerPicker = UIPickerView()
+  private let hours = Array(0...23)
+  private let minutes = Array(0...59)
+  private let seconds = Array(0...59)
+
+  private let hourLabel = UILabel().then {
+    $0.text = "시간"
+  }
+  private let minuteLabel = UILabel().then {
+    $0.text = "분"
+  }
+  private let secondLabel = UILabel().then {
+    $0.text = "초"
+  }
+
+  private let userLabel = UILabel().then {
+    $0.text = "레이블"
+    $0.setContentHuggingPriority(.required, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+  }
+
+  private let userTextField = UITextField().then {
+    $0.placeholder = "타이머"
+    $0.clearButtonMode = .whileEditing
+    $0.textColor = .gray
+    $0.returnKeyType = .done
+    $0.textAlignment = .right
+    $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+  }
+
+  private let userStack = UIStackView().then {
+    $0.axis = .horizontal
+    $0.spacing = 8
+  }
+  //
+  // private let alarmLabel = UILabel().then {
+  //   $0.text = "알람"
+  // }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupPicker()
+    setupLabels()
+    userTextField.delegate = self
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupPicker() {
+    addSubview(timerPicker)
+    timerPicker.delegate = self
+    timerPicker.dataSource = self
+    timerPicker.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(50)
+    }
+  }
+
+  private func setupLabels() {
+    [hourLabel, minuteLabel, secondLabel, userStack].forEach {
+      addSubview($0)
+    }
+
+    [userLabel, userTextField].forEach {
+      userStack.addArrangedSubview($0)
+    }
+
+    // hourLabel.snp.makeConstraints {
+    //   $0.centerY.equalTo(timerPicker)
+    //   // $0.leading.equalTo(timerPicker).offset(10)
+    // }
+
+    // minuteLabel.snp.makeConstraints {
+    //   $0.centerY.equalTo(timerPicker)
+    //   // $0.leading.equalTo(timerPicker).offset(10)
+    // }
+
+    // secondLabel.snp.makeConstraints {
+    //   $0.centerY.equalTo(timerPicker)
+    //   // $0.trailing.equalTo(timerPicker).inset(10)
+    // }
+    //
+    // timerPicker.snp.makeConstraints {
+    //   $0.leading.equalToSuperview().offset(50)
+    //   $0.trailing.equalToSuperview().offset(-50)
+    // }
+
+    userStack.snp.makeConstraints {
+      $0.top.equalTo(timerPicker.snp.bottom)
+      $0.horizontalEdges.equalToSuperview().inset(30)
+    }
+  }
+
+  private var pickerComponentWidth: CGFloat {
+    UIScreen.main.bounds.width / 3
+  }
+
+  var selectedHour: Int {
+    timerPicker.selectedRow(inComponent: 0)
+  }
+
+  var selectedMinute: Int {
+    timerPicker.selectedRow(inComponent: 1)
+  }
+
+  var selectedSecond: Int {
+    timerPicker.selectedRow(inComponent: 2)
+  }
+
+  func selectedTimeInterval() -> TimeInterval {
+    TimeInterval(selectedHour * 3600 + selectedMinute * 60 + selectedSecond)
+  }
+}
+
+extension TimerPickerView: UIPickerViewDelegate, UIPickerViewDataSource {
+  func numberOfComponents(in pickerView: UIPickerView) -> Int {
+    return 3
+  }
+
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    switch component {
+    case 0: return hours.count
+    case 1: return minutes.count
+    case 2: return seconds.count
+    default: return 0
+    }
+  }
+
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    switch component {
+    case 0: return "\(hours[row])"
+    case 2: return "\(minutes[row])"
+    case 1: return "\(seconds[row])"
+    default: return nil
+    }
+  }
+
+  func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+    return pickerView.frame.width / 3
+  }
+}
+
+extension TimerPickerView: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    userTextField.resignFirstResponder()
+    return true
+  }
+}

--- a/Alarm/Scenes/Timer/TimerPickerView.swift
+++ b/Alarm/Scenes/Timer/TimerPickerView.swift
@@ -10,11 +10,12 @@ import Then
 import UIKit
 
 final class TimerPickerView: UIView {
+  // 커스텀 Picker
   private let timerPicker = UIPickerView()
   private let hours = Array(0...23)
   private let minutes = Array(0...59)
   private let seconds = Array(0...59)
-
+  
   private let hourLabel = UILabel().then {
     $0.text = "시간"
   }
@@ -24,13 +25,13 @@ final class TimerPickerView: UIView {
   private let secondLabel = UILabel().then {
     $0.text = "초"
   }
-
+  
   private let userLabel = UILabel().then {
     $0.text = "레이블"
     $0.setContentHuggingPriority(.required, for: .horizontal)
     $0.setContentCompressionResistancePriority(.required, for: .horizontal)
   }
-
+  
   private let userTextField = UITextField().then {
     $0.placeholder = "타이머"
     $0.clearButtonMode = .whileEditing
@@ -40,7 +41,7 @@ final class TimerPickerView: UIView {
     $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
     $0.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
   }
-
+  
   private let userStack = UIStackView().then {
     $0.axis = .horizontal
     $0.spacing = 8
@@ -57,11 +58,11 @@ final class TimerPickerView: UIView {
     setupLabels()
     userTextField.delegate = self
   }
-
+  
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
+  
   private func setupPicker() {
     addSubview(timerPicker)
     timerPicker.delegate = self
@@ -70,41 +71,56 @@ final class TimerPickerView: UIView {
       $0.edges.equalToSuperview().inset(50)
     }
   }
-
+  
   private func setupLabels() {
     [hourLabel, minuteLabel, secondLabel, userStack].forEach {
       addSubview($0)
     }
-
+    
     [userLabel, userTextField].forEach {
       userStack.addArrangedSubview($0)
     }
-
+    
     userStack.snp.makeConstraints {
       $0.top.equalTo(timerPicker.snp.bottom)
       $0.horizontalEdges.equalToSuperview().inset(30)
     }
   }
-
+  
   private var pickerComponentWidth: CGFloat {
+    // 너비 3등분
     UIScreen.main.bounds.width / 3
   }
-
+  
   var selectedHour: Int {
     timerPicker.selectedRow(inComponent: 0)
   }
-
+  
   var selectedMinute: Int {
     timerPicker.selectedRow(inComponent: 1)
   }
-
+  
   var selectedSecond: Int {
     timerPicker.selectedRow(inComponent: 2)
   }
-
+  
   func selectedTimeInterval() -> TimeInterval {
     TimeInterval(selectedHour * 3600 + selectedMinute * 60 + selectedSecond)
   }
+  
+  func userLabelText() -> String {
+    return userTextField.text ?? "타이머"
+  }
+  
+  func selectedTimeComponents() -> TimeComponents {
+    return TimeComponents(hour: selectedHour, minute: selectedMinute, second: selectedSecond)
+  }
+  
+}
+struct TimeComponents {
+    let hour: Int
+    let minute: Int
+    let second: Int
 }
 
 extension TimerPickerView: UIPickerViewDelegate, UIPickerViewDataSource {

--- a/Alarm/Scenes/Timer/TimerPickerView.swift
+++ b/Alarm/Scenes/Timer/TimerPickerView.swift
@@ -44,12 +44,11 @@ final class TimerPickerView: UIView {
   private let userStack = UIStackView().then {
     $0.axis = .horizontal
     $0.spacing = 8
+    $0.layer.cornerRadius = 8
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
   }
-  //
-  // private let alarmLabel = UILabel().then {
-  //   $0.text = "알람"
-  // }
-
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     setupPicker()
@@ -78,26 +77,6 @@ final class TimerPickerView: UIView {
     [userLabel, userTextField].forEach {
       userStack.addArrangedSubview($0)
     }
-
-    // hourLabel.snp.makeConstraints {
-    //   $0.centerY.equalTo(timerPicker)
-    //   // $0.leading.equalTo(timerPicker).offset(10)
-    // }
-
-    // minuteLabel.snp.makeConstraints {
-    //   $0.centerY.equalTo(timerPicker)
-    //   // $0.leading.equalTo(timerPicker).offset(10)
-    // }
-
-    // secondLabel.snp.makeConstraints {
-    //   $0.centerY.equalTo(timerPicker)
-    //   // $0.trailing.equalTo(timerPicker).inset(10)
-    // }
-    //
-    // timerPicker.snp.makeConstraints {
-    //   $0.leading.equalToSuperview().offset(50)
-    //   $0.trailing.equalToSuperview().offset(-50)
-    // }
 
     userStack.snp.makeConstraints {
       $0.top.equalTo(timerPicker.snp.bottom)

--- a/Alarm/Scenes/Timer/TimerPickerView.swift
+++ b/Alarm/Scenes/Timer/TimerPickerView.swift
@@ -47,10 +47,12 @@ final class TimerPickerView: UIView {
     $0.layer.cornerRadius = 8
     $0.isLayoutMarginsRelativeArrangement = true
     $0.layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+    $0.backgroundColor = UIColor(named: "modalColor")
   }
   
   override init(frame: CGRect) {
     super.init(frame: frame)
+    backgroundColor = UIColor(named: "backgroundColor")
     setupPicker()
     setupLabels()
     userTextField.delegate = self

--- a/Alarm/Scenes/Timer/TimerTableViewCell.swift
+++ b/Alarm/Scenes/Timer/TimerTableViewCell.swift
@@ -16,51 +16,48 @@ class TimerTableViewCell: UITableViewCell {
     $0.numberOfLines = 0
     $0.font = .systemFont(ofSize: 50, weight: .light)
   }
-  
+
   private let userLabel = UILabel().then {
     $0.numberOfLines = 4
     $0.lineBreakMode = .byWordWrapping
     $0.font = .systemFont(ofSize: 14, weight: .light)
   }
-  
+
   private let button = UIButton().then {
     $0.setTitle("", for: .normal)
     $0.setTitleColor(UIColor(named: "mainColor"), for: .normal)
-    // $0.titleLabel?.font = .systemFont(ofSize: 20, weight: .bold)
     $0.tintColor = UIColor(named: "mainColor")
     $0.contentHorizontalAlignment = .center
-    
-    // $0.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
-    
+
     $0.layer.cornerRadius = 20
     $0.layer.borderWidth = 3
     $0.layer.borderColor = UIColor(named: "mainColor")?.cgColor
     $0.clipsToBounds = true
     // 􀊆 = Pause
   }
- 
+
   private let labelStack = UIStackView().then {
     $0.alignment = .leading
     $0.axis = .vertical
     $0.spacing = 4
   }
-  
+
   private let fullStack = UIStackView().then {
     $0.alignment = .fill
     $0.spacing = 20
     $0.axis = .horizontal
     $0.layer.cornerRadius = 8
-    // $0.backgroundColor = UIColor(named: "sectionColor")
   }
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     contentView.backgroundColor = UIColor(named: "sectionColor")
+    selectionStyle.self = .none
     backgroundColor = .clear
     contentView.layer.cornerRadius = 8
     setupViews()
   }
-  
+
   override func layoutSubviews() {
     super.layoutSubviews()
     contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 10, bottom: 10, right: 10))
@@ -71,20 +68,6 @@ class TimerTableViewCell: UITableViewCell {
   }
 
   private func setupViews() {
-    // contentView.addSubview(fullStack)
-    // [timerLabel, userLabel].forEach {
-    //   labelStack.addArrangedSubview($0)
-    // }
-    // [labelStack, button].forEach {
-    //   fullStack.addArrangedSubview($0)
-    // }
-    // 
-    // fullStack.snp.makeConstraints {
-    //   $0.top.equalToSuperview().inset(20)
-    //   $0.bottom.equalToSuperview().inset(10)
-    //   $0.leading.equalToSuperview().inset(20)
-    //   $0.trailing.equalToSuperview().offset(-40)
-    // }
     [timerLabel, userLabel, button].forEach {
       addSubview($0)
     }
@@ -93,40 +76,43 @@ class TimerTableViewCell: UITableViewCell {
       $0.top.equalToSuperview().inset(10)
       $0.leading.equalToSuperview().inset(25)
     }
-    
+
     button.snp.makeConstraints {
       $0.centerY.equalTo(timerLabel.snp.centerY)
       $0.trailing.equalToSuperview().inset(30)
       $0.height.width.equalTo(40)
     }
-    
+
     userLabel.snp.makeConstraints {
-      $0.top.equalTo(timerLabel.snp.bottom).offset(-4)
+      $0.top.equalTo(timerLabel.snp.bottom).offset(0)
       $0.leading.equalToSuperview().inset(25)
       $0.trailing.equalTo(button.snp.leading).offset(-10)
       $0.bottom.equalToSuperview().inset(20)
     }
-    
-    // timerLabel.snp.makeConstraints {
-    //   $0.top.equalToSuperview()
-    //   $0.leading.equalToSuperview()
-    // }
-    // 
-    // userLabel.snp.makeConstraints {
-    //   $0.bottom.equalToSuperview()
-    //   $0.leading.equalToSuperview()
-    // }
-   
-    // button.snp.makeConstraints {
-    //   $0.top.equalToSuperview()
-    //   $0.trailing.equalToSuperview()
-    // }
   }
 
   func configureUI(with item: TimerItem) {
-    timerLabel.text = "\(Int(item.time)) 초"
+    timerLabel.text = formattedTime(item.time)
     userLabel.text = "\(item.label)"
     button
       .setImage(item.isActive ? UIImage(systemName: "pause.fill") : UIImage(systemName: "play.fill"), for: .normal)
+  }
+
+  private func formattedTime(_ interval: TimeInterval) -> String {
+    let timeInterval = Int(interval)
+    let hours = timeInterval / 3600
+    let minutes = (timeInterval % 3600) / 60
+    let seconds = timeInterval % 60
+
+    if hours == 0 {
+      // 00:00
+      return String(format: "%02d:%02d", minutes, seconds)
+    } else if hours < 10 {
+      // 0:00:00
+      return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+      // 00:00:00
+      return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
   }
 }

--- a/Alarm/Scenes/Timer/TimerTableViewCell.swift
+++ b/Alarm/Scenes/Timer/TimerTableViewCell.swift
@@ -10,6 +10,8 @@ import Then
 import UIKit
 
 class TimerTableViewCell: UITableViewCell {
+  static let reuseIdentifier = "TimerCell"
+
   private let timerLabel = UILabel().then {
     $0.numberOfLines = 0
     $0.font = .systemFont(ofSize: 50, weight: .light)

--- a/Alarm/Scenes/Timer/TimerTableViewCell.swift
+++ b/Alarm/Scenes/Timer/TimerTableViewCell.swift
@@ -25,16 +25,16 @@ class TimerTableViewCell: UITableViewCell {
   
   private let button = UIButton().then {
     $0.setTitle("", for: .normal)
-    $0.setTitleColor(.systemOrange, for: .normal)
+    $0.setTitleColor(UIColor(named: "mainColor"), for: .normal)
     // $0.titleLabel?.font = .systemFont(ofSize: 20, weight: .bold)
-    $0.tintColor = .systemOrange
+    $0.tintColor = UIColor(named: "mainColor")
     $0.contentHorizontalAlignment = .center
     
     // $0.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
     
     $0.layer.cornerRadius = 20
     $0.layer.borderWidth = 3
-    $0.layer.borderColor = UIColor.systemOrange.cgColor
+    $0.layer.borderColor = UIColor(named: "mainColor")?.cgColor
     $0.clipsToBounds = true
     // 􀊆 = Pause
   }
@@ -50,14 +50,20 @@ class TimerTableViewCell: UITableViewCell {
     $0.spacing = 20
     $0.axis = .horizontal
     $0.layer.cornerRadius = 8
-    $0.backgroundColor = .blue
+    // $0.backgroundColor = UIColor(named: "sectionColor")
   }
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
-    contentView.backgroundColor = .blue
+    contentView.backgroundColor = UIColor(named: "sectionColor")
+    backgroundColor = .clear
     contentView.layer.cornerRadius = 8
     setupViews()
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 10, bottom: 10, right: 10))
   }
 
   required init?(coder: NSCoder) {
@@ -84,21 +90,21 @@ class TimerTableViewCell: UITableViewCell {
     }
 
     timerLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(20)
-      $0.leading.equalToSuperview().inset(10)
+      $0.top.equalToSuperview().inset(10)
+      $0.leading.equalToSuperview().inset(25)
     }
     
     button.snp.makeConstraints {
-      $0.centerY.equalToSuperview()
-      $0.trailing.equalToSuperview().inset(20)
+      $0.centerY.equalTo(timerLabel.snp.centerY)
+      $0.trailing.equalToSuperview().inset(30)
       $0.height.width.equalTo(40)
     }
     
     userLabel.snp.makeConstraints {
-      $0.top.equalTo(timerLabel.snp.bottom).offset(10)
-      $0.leading.equalToSuperview().inset(10)
+      $0.top.equalTo(timerLabel.snp.bottom).offset(-4)
+      $0.leading.equalToSuperview().inset(25)
       $0.trailing.equalTo(button.snp.leading).offset(-10)
-      $0.bottom.equalToSuperview().inset(10)
+      $0.bottom.equalToSuperview().inset(20)
     }
     
     // timerLabel.snp.makeConstraints {

--- a/Alarm/Scenes/Timer/TimerTableViewCell.swift
+++ b/Alarm/Scenes/Timer/TimerTableViewCell.swift
@@ -20,7 +20,7 @@ class TimerTableViewCell: UITableViewCell {
   private let userLabel = UILabel().then {
     $0.numberOfLines = 4
     $0.lineBreakMode = .byWordWrapping
-    $0.font = .systemFont(ofSize: 16, weight: .light)
+    $0.font = .systemFont(ofSize: 14, weight: .light)
   }
   
   private let button = UIButton().then {
@@ -29,6 +29,13 @@ class TimerTableViewCell: UITableViewCell {
     // $0.titleLabel?.font = .systemFont(ofSize: 20, weight: .bold)
     $0.tintColor = .systemOrange
     $0.contentHorizontalAlignment = .center
+    
+    // $0.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+    
+    $0.layer.cornerRadius = 20
+    $0.layer.borderWidth = 3
+    $0.layer.borderColor = UIColor.systemOrange.cgColor
+    $0.clipsToBounds = true
     // 􀊆 = Pause
   }
  
@@ -42,10 +49,14 @@ class TimerTableViewCell: UITableViewCell {
     $0.alignment = .fill
     $0.spacing = 20
     $0.axis = .horizontal
+    $0.layer.cornerRadius = 8
+    $0.backgroundColor = .blue
   }
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+    contentView.backgroundColor = .blue
+    contentView.layer.cornerRadius = 8
     setupViews()
   }
 
@@ -54,35 +65,56 @@ class TimerTableViewCell: UITableViewCell {
   }
 
   private func setupViews() {
-    contentView.addSubview(fullStack)
-    [timerLabel, userLabel].forEach {
-      labelStack.addArrangedSubview($0)
+    // contentView.addSubview(fullStack)
+    // [timerLabel, userLabel].forEach {
+    //   labelStack.addArrangedSubview($0)
+    // }
+    // [labelStack, button].forEach {
+    //   fullStack.addArrangedSubview($0)
+    // }
+    // 
+    // fullStack.snp.makeConstraints {
+    //   $0.top.equalToSuperview().inset(20)
+    //   $0.bottom.equalToSuperview().inset(10)
+    //   $0.leading.equalToSuperview().inset(20)
+    //   $0.trailing.equalToSuperview().offset(-40)
+    // }
+    [timerLabel, userLabel, button].forEach {
+      addSubview($0)
     }
-    [labelStack, button].forEach {
-      fullStack.addArrangedSubview($0)
-    }
-    
-    fullStack.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(20)
-      $0.bottom.equalToSuperview().inset(10)
-      $0.leading.equalToSuperview().inset(20)
-      $0.trailing.equalToSuperview().offset(-40)
-    }
-    
+
     timerLabel.snp.makeConstraints {
-      $0.top.equalToSuperview()
-      $0.leading.equalToSuperview()
+      $0.top.equalToSuperview().inset(20)
+      $0.leading.equalToSuperview().inset(10)
+    }
+    
+    button.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().inset(20)
+      $0.height.width.equalTo(40)
     }
     
     userLabel.snp.makeConstraints {
-      $0.bottom.equalToSuperview()
-      $0.leading.equalToSuperview()
+      $0.top.equalTo(timerLabel.snp.bottom).offset(10)
+      $0.leading.equalToSuperview().inset(10)
+      $0.trailing.equalTo(button.snp.leading).offset(-10)
+      $0.bottom.equalToSuperview().inset(10)
     }
-
-    button.snp.makeConstraints {
-      $0.top.equalToSuperview()
-      $0.trailing.equalToSuperview()
-    }
+    
+    // timerLabel.snp.makeConstraints {
+    //   $0.top.equalToSuperview()
+    //   $0.leading.equalToSuperview()
+    // }
+    // 
+    // userLabel.snp.makeConstraints {
+    //   $0.bottom.equalToSuperview()
+    //   $0.leading.equalToSuperview()
+    // }
+   
+    // button.snp.makeConstraints {
+    //   $0.top.equalToSuperview()
+    //   $0.trailing.equalToSuperview()
+    // }
   }
 
   func configureUI(with item: TimerItem) {

--- a/Alarm/Scenes/Timer/TimerViewController.swift
+++ b/Alarm/Scenes/Timer/TimerViewController.swift
@@ -8,6 +8,7 @@
 import SnapKit
 import Then
 import UIKit
+import RxSwift
 
 final class TimerViewController: UIViewController {
   // MARK: - Lifecycle
@@ -19,42 +20,20 @@ final class TimerViewController: UIViewController {
     $0.backgroundColor = .clear
   }
 
-  let testTimerData: [TimerItem] = [
-    TimerItem(
-      time: 180,
-      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
-      alarmName: "래디얼",
-      isActive: true
-    ),
-    TimerItem(
-      time: 180,
-      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
-      alarmName: "래디얼",
-      isActive: true
-    ),
-    TimerItem(
-      time: 180,
-      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
-      alarmName: "래디얼",
-      isActive: true
-    ),
-    TimerItem(
-      time: 180,
-        label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
-        alarmName: "래디얼",
-        isActive: true
-      ),
-      TimerItem(
-        time: 180,
-      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
-      alarmName: "래디얼",
-      isActive: true
-    ),
-    TimerItem(time: 300, label: "5분", alarmName: "래디얼", isActive: false),
-  ]
-
+  private let disposeBag = DisposeBag()
+  private var timerItems: [TimerItem] = []
+  
   override func viewDidLoad() {
     super.viewDidLoad()
+    TimerDataManager.shared.loadTimers() // 타이머 데이터 조회
+    
+    TimerDataManager.shared.timers // timers에 변동이 생기면
+      .subscribe(onNext: { [weak self] items in
+        self?.timerItems = items
+        self?.timerTableView.reloadData() // 테이블뷰 새로고침
+      })
+      .disposed(by: disposeBag)
+    
     configureUI()
     setupNavigationBar()
   }
@@ -64,7 +43,7 @@ final class TimerViewController: UIViewController {
   private func configureUI() {
     view.backgroundColor = UIColor(named: "backgroundColor")
     title = "타이머"
-    
+
     navigationController?.navigationBar.prefersLargeTitles = true
     navigationItem.largeTitleDisplayMode = .always
 
@@ -95,11 +74,11 @@ final class TimerViewController: UIViewController {
     ).then {
       $0.tintColor = UIColor(named: "mainColor")
     }
-    
+
     let appearance = UINavigationBarAppearance()
     appearance.configureWithOpaqueBackground()
     appearance.backgroundColor = UIColor(named: "backgroundColor")
-    
+
     appearance.shadowColor = .clear
 
     navigationController?.navigationBar.standardAppearance = appearance
@@ -112,15 +91,7 @@ final class TimerViewController: UIViewController {
     nav.modalPresentationStyle = .formSheet
     present(nav, animated: true)
   }
-}
 
-// MARK: - UITableViewDataStruct
-
-struct TimerItem {
-  let time: TimeInterval
-  let label: String
-  let alarmName: String
-  let isActive: Bool
 }
 
 // MARK: - UITableView
@@ -128,16 +99,18 @@ struct TimerItem {
 extension TimerViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     // userDefault.count
-    return testTimerData.count
+    return timerItems.count
   }
 
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard let cell = tableView.dequeueReusableCell(withIdentifier: TimerTableViewCell.reuseIdentifier, for: indexPath) as? TimerTableViewCell
+    guard
+      let cell = tableView.dequeueReusableCell(withIdentifier: TimerTableViewCell.reuseIdentifier, for: indexPath)
+        as? TimerTableViewCell
     else {
       return UITableViewCell()
     }
 
-    let item = testTimerData[indexPath.row]
+    let item = timerItems[indexPath.row]
     cell.configureUI(with: item)
 
     return cell

--- a/Alarm/Scenes/Timer/TimerViewController.swift
+++ b/Alarm/Scenes/Timer/TimerViewController.swift
@@ -6,8 +6,8 @@
 //
 
 import SnapKit
-import UIKit
 import Then
+import UIKit
 
 final class TimerViewController: UIViewController {
   // MARK: - Lifecycle
@@ -25,12 +25,37 @@ final class TimerViewController: UIViewController {
       alarmName: "래디얼",
       isActive: true
     ),
+    TimerItem(
+      time: 180,
+      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
+      alarmName: "래디얼",
+      isActive: true
+    ),
+    TimerItem(
+      time: 180,
+      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
+      alarmName: "래디얼",
+      isActive: true
+    ),
+    TimerItem(
+      time: 180,
+        label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
+        alarmName: "래디얼",
+        isActive: true
+      ),
+      TimerItem(
+        time: 180,
+      label: "4ㅕㄹㅋ햐캏캫ㅋㅎ탸아랴패ㅞㅓㅣ처근런하ㅓ니ㅓ널컬냫ㄴㅎㅛ려려녀쟈래ㅔ헤ㅗㅔㅗㅔㅠㅐㅓㅔㅠㅔㅠㅔ해겯ㄷㅅㄴㅅ아히허여너하파파챠오너아하뎌대하랴야래랴럏ㅇㅅ묘라하러파ㅠㅓ포초포ㅗ퍼포툐용",
+      alarmName: "래디얼",
+      isActive: true
+    ),
     TimerItem(time: 300, label: "5분", alarmName: "래디얼", isActive: false),
   ]
 
   override func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
+    setupNavigationBar()
   }
 
   // MARK: - Private Methods
@@ -38,16 +63,48 @@ final class TimerViewController: UIViewController {
   private func configureUI() {
     view.backgroundColor = .systemBackground
     title = "타이머"
+    
+    navigationController?.navigationBar.prefersLargeTitles = true
+    navigationItem.largeTitleDisplayMode = .always
 
     view.addSubview(timerTableView)
     timerTableView.dataSource = self
-    timerTableView.register(TimerTableViewCell.self, forCellReuseIdentifier: "TimerCell")
+    timerTableView.register(TimerTableViewCell.self, forCellReuseIdentifier: TimerTableViewCell.reuseIdentifier)
 
     timerTableView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
   }
+
+  private func setupNavigationBar() {
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      systemItem: .add,
+      primaryAction: UIAction { [weak self] _ in
+        self?.presentAddTimerViewController()
+      },
+      menu: nil
+    ).then {
+      $0.tintColor = .systemOrange
+    }
+
+    navigationItem.leftBarButtonItem = UIBarButtonItem(
+      title: "편집",
+      primaryAction: nil,
+      menu: nil
+    ).then {
+      $0.tintColor = .systemOrange
+    }
+  }
+
+  private func presentAddTimerViewController() {
+    let addVC = AddTimerViewController()
+    let nav = UINavigationController(rootViewController: addVC)
+    nav.modalPresentationStyle = .formSheet
+    present(nav, animated: true)
+  }
 }
+
+// MARK: - UITableViewDataStruct
 
 struct TimerItem {
   let time: TimeInterval
@@ -56,6 +113,8 @@ struct TimerItem {
   let isActive: Bool
 }
 
+// MARK: - UITableViewDataSource
+
 extension TimerViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     // userDefault.count
@@ -63,7 +122,7 @@ extension TimerViewController: UITableViewDataSource {
   }
 
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard let cell = tableView.dequeueReusableCell(withIdentifier: "TimerCell", for: indexPath) as? TimerTableViewCell
+    guard let cell = tableView.dequeueReusableCell(withIdentifier: TimerTableViewCell.reuseIdentifier, for: indexPath) as? TimerTableViewCell
     else {
       return UITableViewCell()
     }
@@ -74,3 +133,5 @@ extension TimerViewController: UITableViewDataSource {
     return cell
   }
 }
+
+// MARK: Button Function

--- a/Alarm/Scenes/Timer/TimerViewController.swift
+++ b/Alarm/Scenes/Timer/TimerViewController.swift
@@ -14,6 +14,7 @@ final class TimerViewController: UIViewController {
 
   private lazy var timerTableView = UITableView(frame: .zero, style: .plain).then {
     $0.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+    $0.separatorStyle = .none
     $0.showsVerticalScrollIndicator = true
     $0.backgroundColor = .clear
   }
@@ -61,7 +62,7 @@ final class TimerViewController: UIViewController {
   // MARK: - Private Methods
 
   private func configureUI() {
-    view.backgroundColor = .systemBackground
+    view.backgroundColor = UIColor(named: "backgroundColor")
     title = "타이머"
     
     navigationController?.navigationBar.prefersLargeTitles = true
@@ -84,7 +85,7 @@ final class TimerViewController: UIViewController {
       },
       menu: nil
     ).then {
-      $0.tintColor = .systemOrange
+      $0.tintColor = UIColor(named: "mainColor")
     }
 
     navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -92,8 +93,17 @@ final class TimerViewController: UIViewController {
       primaryAction: nil,
       menu: nil
     ).then {
-      $0.tintColor = .systemOrange
+      $0.tintColor = UIColor(named: "mainColor")
     }
+    
+    let appearance = UINavigationBarAppearance()
+    appearance.configureWithOpaqueBackground()
+    appearance.backgroundColor = UIColor(named: "backgroundColor")
+    
+    appearance.shadowColor = .clear
+
+    navigationController?.navigationBar.standardAppearance = appearance
+    navigationController?.navigationBar.scrollEdgeAppearance = appearance
   }
 
   private func presentAddTimerViewController() {
@@ -113,7 +123,7 @@ struct TimerItem {
   let isActive: Bool
 }
 
-// MARK: - UITableViewDataSource
+// MARK: - UITableView
 
 extension TimerViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -133,5 +143,4 @@ extension TimerViewController: UITableViewDataSource {
     return cell
   }
 }
-
 // MARK: Button Function


### PR DESCRIPTION
feat: cell 설정 및 임시 데이터 확인 완료## 🔗 관련 이슈

- #4
- #18
- #20 

## 🔧 PR 요약

- RxSwift로 타이머를 userDefault에 저장. 타이머 데이터 변경이 관측되면 테이블 뷰 reload 및 해당 타이머들 표시
- 커스텀 Picker 생성 및 파일 분리
- 시간 레이블 포맷팅
- 타이머 이름이 빈 칸이면 설정한 시간을 레이블로 사용

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)

> UI 변경이 있다면 스크린샷을 첨부해주세요.
![Simulator Screen Recording - iPhone 16 Pro - 2025-08-07 at 17 44 33](https://github.com/user-attachments/assets/dfe0a8c5-f1e1-436c-b9f2-5fdc909adcaa)


## 📎 기타 참고사항

> 추가적으로 논의하고 싶은 내용이 있다면 작성해주세요.
- 아직 삭제 지원하지 않습니다.
- 타이머 지원하지 않습니다.
- 정렬 지원하지 않습니다.