### PR TITLE
Feat: #48 - 세계시계 셀 UI 구성 및 더미 데이터 연결

### DIFF
--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -28,39 +28,39 @@ final class WorldTimeCell: UITableViewCell {
    └────────────────────────────────────┘
    */
   private let cityLabel = UILabel().then { // 도시명
-    $0.font = .systemFont(ofSize: 20, weight: .semibold)
+    $0.font = .systemFont(ofSize: 24, weight: .medium)
     $0.numberOfLines = 1
     $0.textColor = .label
   }
 
   private let timeDifferenceLabel = UILabel().then { // 오늘, +0시간(GMT)
-    $0.font = .systemFont(ofSize: 13, weight: .regular)
+    $0.font = .systemFont(ofSize: 14, weight: .regular)
   }
 
   private let meridiemLabel = UILabel().then { // 오전/오후
-    $0.font = .systemFont(ofSize: 16, weight: .regular)
+    $0.font = .systemFont(ofSize: 20, weight: .medium)
     $0.textColor = .label
-    $0.setContentHuggingPriority(.required, for: .horizontal) // GMT가 늘어나거나 줄어들거나
   }
 
   private let timeLabel = UILabel().then { // 시간
-    $0.font = .systemFont(ofSize: 25, weight: .bold)
+    $0.font = .systemFont(ofSize: 35, weight: .medium)
     $0.textColor = .label
-    $0.setContentHuggingPriority(.required, for: .horizontal)
   }
   
   private let leftStackView = UIStackView().then { // cityLabel + timeDifferenceLabel
     $0.axis = .vertical
     $0.alignment = .leading
-    $0.distribution = .fillEqually
     $0.spacing = 4
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
   }
 
   private let rightStackView = UIStackView().then { // meridiemLabel + timeLabel
     $0.axis = .horizontal
     $0.alignment = .center
-    $0.distribution = .fill
     $0.spacing = 2
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
   }
 
   private let contentStackView = UIStackView().then { // leftStackView + rightStackView
@@ -83,6 +83,7 @@ final class WorldTimeCell: UITableViewCell {
   // MARK: - Private Methods
   
   private func setupUI() {
+    contentView.backgroundColor = UIColor(named: "backgroundColor")
     selectionStyle = .none // 셀 누름 방지
     timeDifferenceLabel.textColor = UIColor(named: "mainColor")
     
@@ -95,7 +96,7 @@ final class WorldTimeCell: UITableViewCell {
   
   private func setupLayout() {
     containerView.snp.makeConstraints {
-      $0.top.bottom.equalToSuperview()
+      $0.top.bottom.equalToSuperview().inset(3)
       $0.leading.trailing.equalToSuperview().inset(12)
     }
     
@@ -104,6 +105,8 @@ final class WorldTimeCell: UITableViewCell {
     }
   }
   
+  // MARK: - Configure
+
   func configure(_ data: testDataModel) {
     cityLabel.text = data.city
     timeDifferenceLabel.text = data.subInfo

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -5,3 +5,18 @@
 //  Created by 서광용 on 8/7/25.
 //
 
+import UIKit
+import SnapKit
+import Then
+
+final class WorldTimeCell: UITableViewCell {
+ static let id = "WorldTimeCell"
+  
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -38,12 +38,12 @@ final class WorldTimeCell: UITableViewCell {
   }
 
   private let meridiemLabel = UILabel().then { // 오전/오후
-    $0.font = .systemFont(ofSize: 20, weight: .medium)
+    $0.font = .systemFont(ofSize: 20, weight: .light)
     $0.textColor = .label
   }
 
   private let timeLabel = UILabel().then { // 시간
-    $0.font = .systemFont(ofSize: 35, weight: .medium)
+    $0.font = .systemFont(ofSize: 40, weight: .light)
     $0.textColor = .label
   }
   
@@ -51,20 +51,12 @@ final class WorldTimeCell: UITableViewCell {
     $0.axis = .vertical
     $0.alignment = .leading
     $0.spacing = 4
-    $0.isLayoutMarginsRelativeArrangement = true
-    $0.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
   }
 
-  private let rightStackView = UIStackView().then { // meridiemLabel + timeLabel
+  private let contentStackView = UIStackView().then {
     $0.axis = .horizontal
-    $0.alignment = .center
-    $0.spacing = 2
     $0.isLayoutMarginsRelativeArrangement = true
     $0.layoutMargins = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
-  }
-
-  private let contentStackView = UIStackView().then { // leftStackView + rightStackView
-    $0.axis = .horizontal
   }
   
   // MARK: - Lifecycle
@@ -88,20 +80,29 @@ final class WorldTimeCell: UITableViewCell {
     timeDifferenceLabel.textColor = UIColor(named: "mainColor")
     
     contentView.addSubview(containerView)
-    containerView.addSubview(contentStackView)
-    [leftStackView, rightStackView].forEach { contentStackView.addArrangedSubview($0) }
+    [contentStackView, meridiemLabel].forEach { containerView.addSubview($0) }
+    [leftStackView, timeLabel].forEach { contentStackView.addArrangedSubview($0) }
     [cityLabel, timeDifferenceLabel].forEach { leftStackView.addArrangedSubview($0) }
-    [meridiemLabel, timeLabel].forEach { rightStackView.addArrangedSubview($0) }
   }
   
   private func setupLayout() {
     containerView.snp.makeConstraints {
-      $0.top.bottom.equalToSuperview().inset(3)
+      $0.top.bottom.equalToSuperview().inset(4)
       $0.leading.trailing.equalToSuperview().inset(12)
     }
     
     contentStackView.snp.makeConstraints {
       $0.directionalEdges.equalToSuperview()
+    }
+    
+    meridiemLabel.snp.makeConstraints {
+      $0.trailing.equalTo(timeLabel.snp.leading).offset(-4)
+      $0.lastBaseline.equalTo(timeLabel.snp.lastBaseline)
+    }
+    
+    timeLabel.snp.makeConstraints {
+      $0.trailing.equalToSuperview()
+      $0.centerY.equalToSuperview()
     }
   }
   

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -17,6 +17,7 @@ final class WorldTimeCell: UITableViewCell {
   private let containerView = UIView().then {
     $0.layer.cornerRadius = 16
     $0.layer.masksToBounds = true
+    $0.backgroundColor = .section
   }
   /*
    ┌────────────────────────────────────┐
@@ -46,11 +47,15 @@ final class WorldTimeCell: UITableViewCell {
   
   private let leftStackView = UIStackView().then {       // cityLabel + timeDifferenceLabel
     $0.axis = .vertical
-    $0.spacing = 8
+    $0.alignment = .leading
+    $0.distribution = .fillEqually
+    $0.spacing = 4
   }
   private let rightStackView = UIStackView().then {      // meridiemLabel + timeLabel
     $0.axis = .horizontal
-    $0.spacing = 8
+    $0.alignment = .center
+    $0.distribution = .fill
+    $0.spacing = 2
   }
   private let contentStackView = UIStackView().then {    // leftStackView + rightStackView
     $0.axis = .horizontal
@@ -72,17 +77,19 @@ final class WorldTimeCell: UITableViewCell {
   // MARK: - Private Methods
   
   private func setupUI() {
-    timeDifferenceLabel.tintColor = UIColor(named: "mainColor")
+    timeDifferenceLabel.textColor = UIColor(named: "mainColor")
     
     contentView.addSubview(containerView)
     containerView.addSubview(contentStackView)
     [leftStackView, rightStackView].forEach { contentStackView.addArrangedSubview($0) }
     [cityLabel, timeDifferenceLabel].forEach { leftStackView.addArrangedSubview($0) }
     [meridiemLabel, timeLabel].forEach { rightStackView.addArrangedSubview($0) }
-    
   }
   
   private func setupLayout() {
-
+    containerView.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(20)
+    }
   }
 }

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -5,18 +5,84 @@
 //  Created by 서광용 on 8/7/25.
 //
 
-import UIKit
 import SnapKit
 import Then
+import UIKit
 
 final class WorldTimeCell: UITableViewCell {
- static let id = "WorldTimeCell"
+  // MARK: - Properties
+  
+  static let id = "WorldTimeCell"
+  
+  private let containerView = UIView().then {
+    $0.layer.cornerRadius = 16
+    $0.layer.masksToBounds = true
+  }
+  /*
+   ┌────────────────────────────────────┐
+   |  [도시명]                            |
+   | -----------------------------------|
+   |  [GMT/날짜정보] |  [오전/오후] | [시간]  |
+   └────────────────────────────────────┘
+   */
+  private let cityLabel = UILabel().then {               // 도시명
+    $0.font = .systemFont(ofSize: 20, weight: .semibold)
+    $0.numberOfLines = 1
+    $0.textColor = .label
+  }
+  private let timeDifferenceLabel = UILabel().then {     // 오늘, +0시간(GMT)
+    $0.font = .systemFont(ofSize: 13, weight: .regular)
+  }
+  private let meridiemLabel = UILabel().then {           // 오전/오후
+    $0.font = .systemFont(ofSize: 16, weight: .regular)
+    $0.textColor = .label
+    $0.setContentHuggingPriority(.required, for: .horizontal) // GMT가 늘어나거나 줄어들거나
+  }
+  private let timeLabel = UILabel().then {               // 시간
+    $0.font = .systemFont(ofSize: 25, weight: .bold)
+    $0.textColor = .label
+    $0.setContentHuggingPriority(.required, for: .horizontal)
+  }
+  
+  private let leftStackView = UIStackView().then {       // cityLabel + timeDifferenceLabel
+    $0.axis = .vertical
+    $0.spacing = 8
+  }
+  private let rightStackView = UIStackView().then {      // meridiemLabel + timeLabel
+    $0.axis = .horizontal
+    $0.spacing = 8
+  }
+  private let contentStackView = UIStackView().then {    // leftStackView + rightStackView
+    $0.axis = .horizontal
+  }
+  
+  // MARK: - Lifecycle
   
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+    setupUI()
+    setupLayout()
   }
-
+  
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Private Methods
+  
+  private func setupUI() {
+    timeDifferenceLabel.tintColor = UIColor(named: "mainColor")
+    
+    contentView.addSubview(containerView)
+    containerView.addSubview(contentStackView)
+    [leftStackView, rightStackView].forEach { contentStackView.addArrangedSubview($0) }
+    [cityLabel, timeDifferenceLabel].forEach { leftStackView.addArrangedSubview($0) }
+    [meridiemLabel, timeLabel].forEach { rightStackView.addArrangedSubview($0) }
+    
+  }
+  
+  private func setupLayout() {
+
   }
 }

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -19,6 +19,7 @@ final class WorldTimeCell: UITableViewCell {
     $0.layer.masksToBounds = true
     $0.backgroundColor = .section
   }
+
   /*
    ┌────────────────────────────────────┐
    |  [도시명]                            |
@@ -26,38 +27,43 @@ final class WorldTimeCell: UITableViewCell {
    |  [GMT/날짜정보] |  [오전/오후] | [시간]  |
    └────────────────────────────────────┘
    */
-  private let cityLabel = UILabel().then {               // 도시명
+  private let cityLabel = UILabel().then { // 도시명
     $0.font = .systemFont(ofSize: 20, weight: .semibold)
     $0.numberOfLines = 1
     $0.textColor = .label
   }
-  private let timeDifferenceLabel = UILabel().then {     // 오늘, +0시간(GMT)
+
+  private let timeDifferenceLabel = UILabel().then { // 오늘, +0시간(GMT)
     $0.font = .systemFont(ofSize: 13, weight: .regular)
   }
-  private let meridiemLabel = UILabel().then {           // 오전/오후
+
+  private let meridiemLabel = UILabel().then { // 오전/오후
     $0.font = .systemFont(ofSize: 16, weight: .regular)
     $0.textColor = .label
     $0.setContentHuggingPriority(.required, for: .horizontal) // GMT가 늘어나거나 줄어들거나
   }
-  private let timeLabel = UILabel().then {               // 시간
+
+  private let timeLabel = UILabel().then { // 시간
     $0.font = .systemFont(ofSize: 25, weight: .bold)
     $0.textColor = .label
     $0.setContentHuggingPriority(.required, for: .horizontal)
   }
   
-  private let leftStackView = UIStackView().then {       // cityLabel + timeDifferenceLabel
+  private let leftStackView = UIStackView().then { // cityLabel + timeDifferenceLabel
     $0.axis = .vertical
     $0.alignment = .leading
     $0.distribution = .fillEqually
     $0.spacing = 4
   }
-  private let rightStackView = UIStackView().then {      // meridiemLabel + timeLabel
+
+  private let rightStackView = UIStackView().then { // meridiemLabel + timeLabel
     $0.axis = .horizontal
     $0.alignment = .center
     $0.distribution = .fill
     $0.spacing = 2
   }
-  private let contentStackView = UIStackView().then {    // leftStackView + rightStackView
+
+  private let contentStackView = UIStackView().then { // leftStackView + rightStackView
     $0.axis = .horizontal
   }
   
@@ -77,6 +83,7 @@ final class WorldTimeCell: UITableViewCell {
   // MARK: - Private Methods
   
   private func setupUI() {
+    selectionStyle = .none // 셀 누름 방지
     timeDifferenceLabel.textColor = UIColor(named: "mainColor")
     
     contentView.addSubview(containerView)
@@ -89,7 +96,18 @@ final class WorldTimeCell: UITableViewCell {
   private func setupLayout() {
     containerView.snp.makeConstraints {
       $0.top.bottom.equalToSuperview()
-      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.leading.trailing.equalToSuperview().inset(12)
     }
+    
+    contentStackView.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
+    }
+  }
+  
+  func configure(_ data: testDataModel) {
+    cityLabel.text = data.city
+    timeDifferenceLabel.text = data.subInfo
+    meridiemLabel.text = data.meridiem
+    timeLabel.text = data.time
   }
 }

--- a/Alarm/Scenes/WorldTime/WorldTimeCell.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeCell.swift
@@ -72,6 +72,13 @@ final class WorldTimeCell: UITableViewCell {
     fatalError("init(coder:) has not been implemented")
   }
   
+  override func setEditing(_ editing: Bool, animated: Bool) {
+    super.setEditing(editing, animated: animated)
+    meridiemLabel.isHidden = editing
+    timeLabel.isHidden = editing
+    backgroundColor = UIColor(named: "backgroundColor")
+  }
+  
   // MARK: - Private Methods
   
   private func setupUI() {

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -17,6 +17,7 @@ final class WorldTimeViewController: UIViewController {
   private let backgroundColor = UIColor(named: "backgroundColor")
   private let mainColor = UIColor(named: "mainColor")
 
+  private let viewModel = WorldTimeViewModel()
   private let tableView = UITableView()
 
   private let editButton = UIBarButtonItem(title: "편집", style: .plain, target: nil, action: nil)
@@ -49,7 +50,7 @@ final class WorldTimeViewController: UIViewController {
     view.backgroundColor = backgroundColor
     view.addSubview(tableView)
     tableView.backgroundColor = backgroundColor
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: WorldTimeCell.id)
+    tableView.register(WorldTimeCell.self, forCellReuseIdentifier: WorldTimeCell.id)
   }
 
   private func setupLayout() {
@@ -79,14 +80,11 @@ final class WorldTimeViewController: UIViewController {
       })
       .disposed(by: disposeBag)
 
-    // MARK: - 테이블뷰 아이템 바인딩 (더미 데이터)
+    // MARK: - cell에 데이터 바인딩
 
-    itemsRelay
-      .asDriver(onErrorJustReturn: []) // Driver<[String]>로 변환, 에러 시 빈 배열
-      .drive(tableView.rx.items(cellIdentifier: WorldTimeCell.id)) { _, city, cell in // (row, element, cell)
-        cell.textLabel?.text = city
-        cell.selectionStyle = .none
-        cell.backgroundColor = self.backgroundColor
+    viewModel.timesRelay
+      .bind(to: tableView.rx.items(cellIdentifier: WorldTimeCell.id, cellType: WorldTimeCell.self)) { _, model, cell in
+        cell.configure(model)
       }
       .disposed(by: disposeBag)
 

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -31,15 +31,15 @@ final class WorldTimeViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    configureUI()
-    configureLayout()
-    configureNavigationBar()
+    setupUI()
+    setupLayout()
+    setupNavigationBar()
     bind()
   }
 
   // MARK: - Private Methods
 
-  private func configureUI() {
+  private func setupUI() {
     title = "세계 시계"
     navigationController?.navigationBar.prefersLargeTitles = true // LargeTitles
     navigationController?.navigationBar.largeTitleTextAttributes = [
@@ -52,7 +52,7 @@ final class WorldTimeViewController: UIViewController {
     tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
   }
 
-  private func configureLayout() {
+  private func setupLayout() {
     tableView.snp.makeConstraints {
       $0.edges.equalTo(view.safeAreaLayoutGuide)
     }
@@ -60,7 +60,7 @@ final class WorldTimeViewController: UIViewController {
 
   // MARK: - 네비게이션 바 추가
 
-  private func configureNavigationBar() {
+  private func setupNavigationBar() {
     navigationItem.leftBarButtonItem = editButton
     navigationItem.rightBarButtonItem = addButton
     editButton.tintColor = mainColor

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -18,6 +18,7 @@ final class WorldTimeViewController: UIViewController {
   private let mainColor = UIColor(named: "mainColor")
 
   private let viewModel = WorldTimeViewModel()
+  
   private lazy var tableView = UITableView().then {
     $0.separatorStyle = .none
     $0.register(WorldTimeCell.self, forCellReuseIdentifier: WorldTimeCell.id)
@@ -28,7 +29,6 @@ final class WorldTimeViewController: UIViewController {
   private let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
 
   private var isEditingMode = false
-  private let itemsRelay = BehaviorRelay<[String]>(value: ["서울", "도쿄", "런던", "파리", "로마"])
 
   private let disposeBag = DisposeBag()
 
@@ -72,6 +72,7 @@ final class WorldTimeViewController: UIViewController {
 
   private func bind() {
     tableView.rx.setDelegate(self).disposed(by: disposeBag) // delegate
+
     // MARK: - 편집 모드
 
     editButton.rx.tap
@@ -92,13 +93,12 @@ final class WorldTimeViewController: UIViewController {
       .disposed(by: disposeBag)
 
     // MARK: - 스와이프 삭제
+
     // TODO: 삭제 데이터가 다른곳으로 가야함
     tableView.rx.itemDeleted
       .withUnretained(self)
       .subscribe(onNext: { vc, indexPath in
-        var newItems = vc.itemsRelay.value
-        newItems.remove(at: indexPath.row)
-        vc.itemsRelay.accept(newItems) // accept는 덮어쓰기 느낌 (교체)
+        vc.viewModel.deleteItem(indexPath.row)
       })
       .disposed(by: disposeBag)
 
@@ -107,11 +107,8 @@ final class WorldTimeViewController: UIViewController {
     tableView.rx.itemMoved
       .withUnretained(self)
       .subscribe(onNext: { vc, move in
-        var newItems = vc.itemsRelay.value
         // sourceIndex: 드래그 시작한 셀의 위치, destinationIndex: 드롭 도착한 셀의 위치
-        let moved = newItems.remove(at: move.sourceIndex.row) // 값을 꺼내면서 배열에서 삭제
-        newItems.insert(moved, at: move.destinationIndex.row)
-        vc.itemsRelay.accept(newItems)
+        vc.viewModel.moveItem(fromIndex: move.sourceIndex.row, toIndex: move.destinationIndex.row)
       })
       .disposed(by: disposeBag)
 

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -18,7 +18,11 @@ final class WorldTimeViewController: UIViewController {
   private let mainColor = UIColor(named: "mainColor")
 
   private let viewModel = WorldTimeViewModel()
-  private let tableView = UITableView()
+  private lazy var tableView = UITableView().then {
+    $0.separatorStyle = .none
+    $0.register(WorldTimeCell.self, forCellReuseIdentifier: WorldTimeCell.id)
+    $0.backgroundColor = backgroundColor
+  }
 
   private let editButton = UIBarButtonItem(title: "편집", style: .plain, target: nil, action: nil)
   private let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
@@ -49,8 +53,6 @@ final class WorldTimeViewController: UIViewController {
 
     view.backgroundColor = backgroundColor
     view.addSubview(tableView)
-    tableView.backgroundColor = backgroundColor
-    tableView.register(WorldTimeCell.self, forCellReuseIdentifier: WorldTimeCell.id)
   }
 
   private func setupLayout() {

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -71,6 +71,7 @@ final class WorldTimeViewController: UIViewController {
   }
 
   private func bind() {
+    tableView.rx.setDelegate(self).disposed(by: disposeBag) // delegate
     // MARK: - 편집 모드
 
     editButton.rx.tap
@@ -91,7 +92,7 @@ final class WorldTimeViewController: UIViewController {
       .disposed(by: disposeBag)
 
     // MARK: - 스와이프 삭제
-
+    // TODO: 삭제 데이터가 다른곳으로 가야함
     tableView.rx.itemDeleted
       .withUnretained(self)
       .subscribe(onNext: { vc, indexPath in
@@ -123,5 +124,11 @@ final class WorldTimeViewController: UIViewController {
         // TODO: Modal 페이지로 이동 구현
       })
       .disposed(by: disposeBag)
+  }
+}
+
+extension WorldTimeViewController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+    "삭제"
   }
 }

--- a/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewController.swift
@@ -49,7 +49,7 @@ final class WorldTimeViewController: UIViewController {
     view.backgroundColor = backgroundColor
     view.addSubview(tableView)
     tableView.backgroundColor = backgroundColor
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: WorldTimeCell.id)
   }
 
   private func setupLayout() {
@@ -83,7 +83,7 @@ final class WorldTimeViewController: UIViewController {
 
     itemsRelay
       .asDriver(onErrorJustReturn: []) // Driver<[String]>로 변환, 에러 시 빈 배열
-      .drive(tableView.rx.items(cellIdentifier: "cell")) { _, city, cell in // (row, element, cell)
+      .drive(tableView.rx.items(cellIdentifier: WorldTimeCell.id)) { _, city, cell in // (row, element, cell)
         cell.textLabel?.text = city
         cell.selectionStyle = .none
         cell.backgroundColor = self.backgroundColor

--- a/Alarm/Scenes/WorldTime/WorldTimeViewModel.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  WorldTimeViewModel.swift
+//  Alarm
+//
+//  Created by 서광용 on 8/9/25.
+//
+
+import RxCocoa
+import RxSwift
+
+struct testDataModel {
+  let city: String
+  let subInfo: String
+  let meridiem: String
+  let time: String
+}
+
+final class WorldTimeViewModel {
+  // 더미 데이터
+  let timesRelay = BehaviorRelay<[testDataModel]>(value: [
+    .init(city: "호브드", subInfo: "오늘, -2시간", meridiem: "오후", time: "09:34"),
+    .init(city: "과테말라 시티", subInfo: "오늘, -15시간", meridiem: "오전", time: "08:34"),
+    .init(city: "괌", subInfo: "내일, +1시간", meridiem: "오전", time: "00:35"),
+    .init(city: "고텐부르크", subInfo: "오늘, -7시간", meridiem: "오후", time: "04:35")
+  ])
+}

--- a/Alarm/Scenes/WorldTime/WorldTimeViewModel.swift
+++ b/Alarm/Scenes/WorldTime/WorldTimeViewModel.swift
@@ -23,4 +23,17 @@ final class WorldTimeViewModel {
     .init(city: "괌", subInfo: "내일, +1시간", meridiem: "오전", time: "00:35"),
     .init(city: "고텐부르크", subInfo: "오늘, -7시간", meridiem: "오후", time: "04:35")
   ])
+
+  func deleteItem(_ index: Int) {
+    var items = timesRelay.value
+    items.remove(at: index)
+    timesRelay.accept(items)
+  }
+
+  func moveItem(fromIndex: Int, toIndex: Int) {
+    var items = timesRelay.value
+    let moved = items.remove(at: fromIndex)
+    items.insert(moved, at: toIndex)
+    timesRelay.accept(items)
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #48 

## 🔧 PR 요약
- 세계시계 화면의 커스텀 셀 UI 구현
  - 도시 이름 라벨, GMT 표시 라벨, 현재 시간/오전·오후 라벨 구성
- 더미 데이터 기반으로 삭제 및 순서 이동 기능 구현
  - 삭제·이동 로직을 ViewModel로 이전하여 관리
- 편집 모드 진입 시 셀 가로 공간 확보를 위해 오전/오후, 시간 라벨 hidden 처리
  - 아이폰 알람 앱 UI 참고

## ✅ 작업 내용 체크리스트

- [ ] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
![Image](https://github.com/user-attachments/assets/8fd0690f-5295-45b3-8546-1b6765843ac3)


## 📎 기타 참고사항
- `feat/28-worldclock-ui`가 `develop`에 머지된 이후, 이 PR의 base를 `develop`으로 변경하고 최신화할 예정입니다.
- 반드시 #28 merge 후 이 PR을 merge하는 순서로 진행할 예정입니다.
