### PR TITLE
feat: #50 - 스톱워치 재설정 기능 구현

### DIFF
--- a/Alarm/Scenes/Stopwatch/StopWatchViewModel.swift
+++ b/Alarm/Scenes/Stopwatch/StopWatchViewModel.swift
@@ -62,4 +62,16 @@ final class StopwatchViewModel {
     timerDisposable = nil
     startDate = nil // 시작 시각 초기화
   }
+
+  // 타이머 초기화
+  func resetTimer() {
+    stopTimer()
+    totalTime = 0
+    timePassed.accept(0)
+  }
+
+  // 랩 타임 기록 임시
+  func recordLap() {
+    print("laptime recorded")
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #50 

## 🔧 PR 요약

- 타이머 시작 시 lapReset 버튼 활성화 및 랩타임 이미지로 변환
- 타이머 종료 시 lapReset 버튼 삭제 이미지로 변환
- 타이머 재설정 버튼 클릭 시 lapReset 버튼 비활성화 및 타이머 초기화

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷
![Simulator Screen Recording - iPhone 16e - 2025-08-10 at 19 37 02](https://github.com/user-attachments/assets/cf543176-a169-46bc-8261-909915e95bd3)

* gif 로 볼때는 버튼 이미지가 잘 안바뀌지만 시뮬레이터에서는 잘 바뀌는거 확인했습니다!

