### PR TITLE
chore: #90 일시정지인 타이머는 회색으로 보이게 변경

### DIFF
--- a/Alarm/Scenes/Timer/TimerTableViewCell.swift
+++ b/Alarm/Scenes/Timer/TimerTableViewCell.swift
@@ -99,6 +99,7 @@ class TimerTableViewCell: UITableViewCell {
     button  // 활성 상태에 따른 아이콘 토글
       .setImage(item.isActive ? UIImage(systemName: "pause.fill") : UIImage(systemName: "play.fill"), for: .normal)
     button.removeTarget(nil, action: nil, for: .allEvents)  // 재사용된 cell에서 중복 실행 방지를 위한 target remove
+    timerLabel.textColor = item.isActive ? .white : .gray // 일시정지일 때 텍스트 회색으로
     button.addTarget(self, action: #selector(toggleActive), for: .touchUpInside)  // 아이콘 토글
   }
 


### PR DESCRIPTION
타이머 재생 = 흰 색

## 🔗 관련 이슈

- #90

## 🔧 PR 요약

- 일시정지를 하면 타이머 시간이 회색으로, 진행할 때는 다시 흰색으로 변합니다.

## ✅ 작업 내용 체크리스트

- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 15 Pro - 2025-08-12 at 16 38 25](https://github.com/user-attachments/assets/033b6d39-18d0-412e-9477-b8cf1ecb4849)


> UI 변경이 있다면 스크린샷을 첨부해주세요.

## 📎 기타 참고사항

> 추가적으로 논의하고 싶은 내용이 있다면 작성해주세요.
